### PR TITLE
Change up save methods

### DIFF
--- a/includes/class-page-for-post-types-activator.php
+++ b/includes/class-page-for-post-types-activator.php
@@ -31,11 +31,5 @@ class Page_For_Post_Types_Activator {
 	 */
 	public static function activate() {
 
-		$uuid = get_option( 'page_for_post_types_uuid' );
-		if ( ! $uuid ) {
-			$uuid = wp_generate_uuid4();
-			update_option( 'page_for_post_types_uuid', $uuid, true );
-		}
 	}
-
 }

--- a/includes/class-page-for-post-types-functions.php
+++ b/includes/class-page-for-post-types-functions.php
@@ -7,17 +7,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Page_For_Post_Types_Functions {
 
 	/**
-	 * Retrieves the UUID set on plugin activation.
-	 *
-	 * @return mixed|void
-	 * @since 1.0.0
-	 */
-	public static function get_uuid() {
-
-		return get_option( 'page_for_post_types_uuid' );
-	}
-
-	/**
 	 * Returns compiled option name for post type
 	 *
 	 * @param string $suffix
@@ -27,9 +16,7 @@ class Page_For_Post_Types_Functions {
 	 */
 	public static function option_name( $suffix ) {
 
-		$prefix = Page_For_Post_Types_Functions::get_uuid();
-
-		return sprintf( '%1$s_page_for_%2$s', $prefix, $suffix );
+		return sprintf( 'page_for_%1$s', $suffix );
 	}
 
 	/**

--- a/includes/class-page-for-post-types-shared.php
+++ b/includes/class-page-for-post-types-shared.php
@@ -63,17 +63,6 @@ class Page_For_Post_Types_Shared {
 	}
 
 	/**
-	 * Retrieves the UUID set on plugin activation.
-	 *
-	 * @return mixed|void
-	 * @since 1.0.0
-	 */
-	public function get_uuid() {
-
-		return get_option( 'page_for_post_types_uuid' );
-	}
-
-	/**
 	 * Returns the option setting.
 	 *
 	 * @param string $suffix
@@ -96,9 +85,7 @@ class Page_For_Post_Types_Shared {
 	 */
 	public function option_name( $suffix ) {
 
-		$prefix = $this->get_uuid();
-
-		return sprintf( '%1$s_page_for_%2$s', $prefix, $suffix );
+		return sprintf( 'page_for_%1$s', $suffix );
 	}
 
 	/**

--- a/includes/class-page-for-post-types.php
+++ b/includes/class-page-for-post-types.php
@@ -172,6 +172,7 @@ class Page_For_Post_Types {
 		$this->loader->add_filter( 'display_post_states', $plugin_admin, 'filter_post_states', 10, 2 );
 		$this->loader->add_filter( 'plugin_action_links_' . PAGE_FOR_POST_TYPES_PATH, $plugin_admin, 'add_plugin_action_links', 10, 4 );
 
+		$this->loader->add_action( 'pre_update_option_page_for_post_type_keys_hidden', $plugin_admin, 'update_options', 20, 0 );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -30,9 +30,13 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-$page_for_post_types_uuid = get_option( 'page_for_post_types_uuid' );
+// Get the option that holds the post type page option names.
+$page_for_post_types_keys = get_option( 'page_for_post_types_keys' );
 
-global $wpdb;
-$wpdb->query( $wpdb->prepare( 'DELETE FROM `{$wpdb->prefix}options` WHERE option_name LIKE %s', $wpdb->esc_like( $page_for_post_types_uuid ) . '%' ) );
+// Delete each individual post type page option.
+foreach ( $page_for_post_types_keys as $page_for_post_types_key ) {
+	delete_option( $page_for_post_types_key );
+}
 
-delete_option( 'page_for_post_types_uuid' );
+// Finally, delete the key option.
+delete_option( 'page_for_post_types_keys' );


### PR DESCRIPTION
This new storage method also adds a sanitization callback to our options. If the value is set to 0, then the data is not stored in the DB.

It also saves a plural option, so that `page_for_book` or `page_for_books` will both work. If the post type name is news, you'd only get `page_for_news`, not `page_for_newss`.